### PR TITLE
[FEAT] Feat/chatTest 추천질문 기능 , 예약 가능여부 확인 기능 

### DIFF
--- a/src/main/java/com/backend/nova/chat/controller/ChatController.java
+++ b/src/main/java/com/backend/nova/chat/controller/ChatController.java
@@ -1,6 +1,6 @@
 package com.backend.nova.chat.controller;
 
-// ✅ Controller는 "HTTP 요청/응답"만 담당한다.
+//  Controller는 "HTTP 요청/응답"만 담당한다.
 //    - 실제 비즈니스 로직(LLM 호출, DB 조회 등)은 Service 계층으로 위임한다.
 //    - 요청/응답 데이터 구조는 DTO로 분리한다.
 

--- a/src/main/java/com/backend/nova/chat/controller/ChatSuggestionController.java
+++ b/src/main/java/com/backend/nova/chat/controller/ChatSuggestionController.java
@@ -1,0 +1,30 @@
+package com.backend.nova.chat.controller;
+
+import com.backend.nova.chat.dto.ChatSuggestionResponse;
+import com.backend.nova.chat.service.ChatSuggestionService;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/chat")
+public class ChatSuggestionController {
+
+    private final ChatSuggestionService chatSuggestionService;
+
+    @Operation(
+            summary = "추천 질문 목록 조회",
+            description = """
+                    챗봇 하단 '추천 질문' 버튼에 노출할 문구 리스트를 반환합니다.
+                    - label: 버튼에 표시될 텍스트
+                    - message: 버튼 클릭 시 /api/chat 으로 전송할 실제 메시지
+                    """
+    )
+    @GetMapping("/suggestions")
+    public ChatSuggestionResponse suggestions(
+            @RequestParam(required = false) Long residentId
+    ) {
+        return chatSuggestionService.getSuggestions(residentId);
+    }
+}

--- a/src/main/java/com/backend/nova/chat/dto/ChatSuggestionResponse.java
+++ b/src/main/java/com/backend/nova/chat/dto/ChatSuggestionResponse.java
@@ -1,0 +1,12 @@
+package com.backend.nova.chat.dto;
+
+import java.util.List;
+
+public record ChatSuggestionResponse(
+        List<SuggestionItem> suggestion
+) {
+    public record SuggestionItem(
+            String label, //실제 버튼에 표시될 문구
+            String message //실제 /api/chat으로 보낼 문구
+    ){}
+}

--- a/src/main/java/com/backend/nova/chat/service/ChatService.java
+++ b/src/main/java/com/backend/nova/chat/service/ChatService.java
@@ -322,12 +322,16 @@ public class ChatService {
         Facility facility = facilityRepository
                 .findByApartmentIdAndName(apartmentId, facilityName)
                 .orElseThrow(() -> new IllegalArgumentException("시설 정보를 찾을 수 없습니다: " + facilityName));
+        boolean reservable = facility.isReservationAvailable();
+
+        String reservableText = reservable ? "현재 예약 가능합니다." : "현재 예약이 불가능합니다.";
 
         String answer = String.format(
                 "%s 운영 시간은 %s ~ %s 입니다.",
                 facility.getName(),
                 facility.getStartHour(),
-                facility.getEndHour()
+                facility.getEndHour(),
+                reservableText
         );
 
         return new ChatResponse(

--- a/src/main/java/com/backend/nova/chat/service/ChatService.java
+++ b/src/main/java/com/backend/nova/chat/service/ChatService.java
@@ -32,6 +32,7 @@ import org.springframework.util.StreamUtils;
 
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -305,6 +306,8 @@ public class ChatService {
     // intent handlers
     // =========================
 
+
+
     private ChatResponse handleFacilityInfo(String sessionId, ChatRequest req, LlmCommand cmd) {
         Ho ho = resolveHo(req.residentId());
         Long apartmentId = resolveApartmentId(ho);
@@ -313,25 +316,42 @@ public class ChatService {
         if (facilityName.isBlank()) {
             return new ChatResponse(
                     sessionId,
-                    "어떤 시설 운영시간을 조회할까요? (예: 헬스장, 수영장)",
+                    "어느 시설을 확인할까요? (헬스장/스터디룸/수영장...)",
                     "FACILITY_INFO",
-                    Map.of("needs", "facility")
+                    Map.of("facility", "UNKNOWN", "info_type", "UNKNOWN")
             );
         }
 
         Facility facility = facilityRepository
                 .findByApartmentIdAndName(apartmentId, facilityName)
                 .orElseThrow(() -> new IllegalArgumentException("시설 정보를 찾을 수 없습니다: " + facilityName));
-        boolean reservable = facility.isReservationAvailable();
 
-        String reservableText = reservable ? "현재 예약 가능합니다." : "현재 예약이 불가능합니다.";
+        //  1) 운영중 여부
+        LocalTime now = LocalTime.now();
+        LocalTime start = facility.getStartHour();
+        LocalTime end = facility.getEndHour();
+
+        boolean isOpenNow;
+        // end가 start보다 작으면(예: 22:00~06:00) 자정 넘어가는 케이스 처리
+        if (end.isAfter(start) || end.equals(start)) {
+            isOpenNow = !now.isBefore(start) && !now.isAfter(end);
+        } else {
+            isOpenNow = !now.isBefore(start) || !now.isAfter(end);
+        }
+
+        //  2) 예약 기능 가능 여부(컬럼)
+        boolean reservationAvailable = facility.isReservationAvailable(); // getter 맞춰서 수정
+
+        //  3) “지금 예약 가능” 결론
+        boolean reservableNow = isOpenNow && reservationAvailable;
 
         String answer = String.format(
-                "%s 운영 시간은 %s ~ %s 입니다.",
+                "%s 운영시간은 %s~%s이고, 지금은 %s입니다. %s",
                 facility.getName(),
-                facility.getStartHour(),
-                facility.getEndHour(),
-                reservableText
+                start,
+                end,
+                isOpenNow ? "운영 중" : "운영 시간이 아니에요",
+                reservableNow ? "현재 예약 가능합니다." : "현재 예약이 불가능합니다."
         );
 
         return new ChatResponse(
@@ -340,13 +360,18 @@ public class ChatService {
                 "FACILITY_INFO",
                 Map.of(
                         "facility", facility.getName(),
-                        "startHour", facility.getStartHour(),
-                        "endHour", facility.getEndHour(),
+                        "info_type", "AVAILABLE",
+                        "startHour", start,
+                        "endHour", end,
+                        "isOpenNow", isOpenNow,
+                        "reservationAvailable", reservationAvailable,
+                        "reservableNow", reservableNow,
                         "apartmentId", apartmentId,
                         "description", facility.getDescription()
                 )
         );
     }
+
 
     private ChatResponse handleEnvStatus(String sessionId, ChatRequest req, LlmCommand cmd) {
         Ho ho = resolveHo(req.residentId());

--- a/src/main/java/com/backend/nova/chat/service/ChatSuggestionService.java
+++ b/src/main/java/com/backend/nova/chat/service/ChatSuggestionService.java
@@ -1,0 +1,25 @@
+package com.backend.nova.chat.service;
+
+import com.backend.nova.chat.dto.ChatSuggestionResponse;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class ChatSuggestionService {
+
+    public ChatSuggestionResponse getSuggestions(Long residentId) {
+        // - 향후 "입주민 권한/거주 동/호"에 따라 추천질문 다르게 내려주기 쉬움
+        // 지금은 일단 공통 추천질문으로 내려줌
+
+        List<ChatSuggestionResponse.SuggestionItem> items = List.of(
+                new ChatSuggestionResponse.SuggestionItem("오늘 아파트 행사 있어?", "오늘 아파트 행사 있어?"),
+                new ChatSuggestionResponse.SuggestionItem("내 예약 정보 알려줘", "내 예약 정보 알려줘"),
+                new ChatSuggestionResponse.SuggestionItem("지금 잡 온도 알려줘", "거실 온도 알려줘"),
+                new ChatSuggestionResponse.SuggestionItem("관리비 얼마야?", "관리비 얼마야?"),
+                new ChatSuggestionResponse.SuggestionItem("거실 조명 켜줘", "거실 조명 켜줘")
+        );
+
+        return new ChatSuggestionResponse(items);
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -14,7 +14,7 @@ spring:
     defer-datasource-initialization: true
     show-sql: true # 실행되는 SQL 쿼리를 콘솔에 출력
     hibernate:
-      ddl-auto: update # DDL 자동 생성 전략 (none / create / validate / update)
+      ddl-auto: none # DDL 자동 생성 전략 (none / create / validate / update)
     properties:
       hibernate:
         format_sql: true # 로그에 출력되는 SQL을 보기 좋게 포맷팅

--- a/src/main/resources/prompt/chat-system.st
+++ b/src/main/resources/prompt/chat-system.st
@@ -1,160 +1,133 @@
-[출력 형식 절대 규칙]
+너는 스마트홈 아파트 AI 어시스턴트다.
+사용자의 질문을 분석하여 반드시 아래 JSON 스키마에 맞는 객체 1개만 출력해야 한다.
 
-반드시 JSON 객체 1개만 출력한다.
+[출력 절대 규칙]
+- 반드시 JSON 객체 1개만 출력한다.
+- JSON 외의 문자는 단 1글자도 출력하지 않는다.
+- 코드블록(json, ``` 등)을 절대 사용하지 않는다.
+- 모든 키 이름은 스키마에서 지정한 이름을 그대로 사용한다.
+- 모든 값은 JSON 규격을 따른다.
+- slots는 반드시 객체 {} 형태이며 null을 사용하지 않는다.
+- intent는 아래 enum 중 정확히 1개만 선택한다.
 
-JSON 외의 문자는 단 1글자도 출력하면 안 된다. (설명/주석/머리말/꼬리말/개행 텍스트/이모지 금지)
-
-코드블록(json, ) 절대 사용 금지.
-
-키 이름은 아래 스키마에서 단 하나도 바꾸지 말고 그대로 사용한다.
-
-모든 값은 JSON 규격을 준수한다. (true/false는 boolean, 따옴표 필수 등)
-
-slots는 반드시 객체 {} 형태이며 null을 쓰지 않는다. 값이 없으면 {} 또는 ""를 사용한다.
-
-intent는 아래 enum 중 정확히 1개만 선택한다.
-
-[반드시 출력해야 하는 JSON 스키마]
+[출력 JSON 스키마]
 {
-"intent": "IOT_CONTROL|ENV_STATUS|FACILITY_INFO|RESERVATION_LOOKUP|RAG_POLICY|SMALL_TALK|UNKNOWN",
-"reply": "사용자에게 보여줄 짧은 문장",
-"slots": {},
-"needs_clarification": true|false,
-"clarify_question": ""
+  "intent": "IOT_CONTROL|ENV_STATUS|FACILITY_INFO|RESERVATION_LOOKUP|RAG_POLICY|SMALL_TALK|UNKNOWN",
+  "reply": "사용자에게 보여줄 짧은 1문장",
+  "slots": {},
+  "needs_clarification": true|false,
+  "clarify_question": ""
 }
 
-[intent 정의]
+────────────────────────
+[intent 판단 기준]
 
-IOT_CONTROL
+1. IOT_CONTROL
+- 집 안 기기(조명, 에어컨, 난방 등)를 켜기/끄기/설정 변경 요청
+- 예: “거실 불 꺼줘”, “에어컨 켜”, “온도 24도로 맞춰줘”
 
-사용자가 집 안 기기(LED, 에어컨, 난방, 가습기 등)를 켜기/끄기/설정 변경하려는 요청
+2. ENV_STATUS
+- 실내 환경 상태 조회(온도/습도/조도 등)
+- 예: “거실 온도 알려줘”, “습도 몇이야”
 
-예: “거실 불 꺼줘”, “온도 24도로 맞춰줘”, “에어컨 켜줘”
+3. FACILITY_INFO
+- 단지 시설 정보 조회
+- 운영시간, 예약 가능 여부, 시설 설명 포함
+- 예: 
+  - “헬스장 운영시간”
+  - “스터디룸 예약 가능해?”
+  - “수영장 지금 예약돼?”
 
-ENV_STATUS
+※ “예약 가능해?”라도
+  - ‘내 예약 조회’가 아니라
+  - ‘시설의 예약 가능 여부’를 묻는 경우
+  → FACILITY_INFO 로 분류한다.
 
-실내 환경 상태 조회(온도/습도/미세먼지 등) 또는 센서값 조회
+4. RESERVATION_LOOKUP
+- 사용자의 예약 내역 조회
+- 예:
+  - “내 예약 보여줘”
+  - “오늘 예약 있어?”
+  - “헬스장 예약 내역”
 
-예: “거실 온도 알려줘”, “습도 몇이야?”
+5. RAG_POLICY
+- 관리 규약/공지/규정/민원 관련 질문
+- 예: “분리수거 시간”, “주차 규칙”
 
-FACILITY_INFO
+6. SMALL_TALK
+- 인사/잡담
+- 예: “안녕”, “고마워”
 
-단지 커뮤니티 시설 정보 조회(운영시간/예약가능 여부/설명)
+7. UNKNOWN
+- 위 기준에 명확히 속하지 않거나 의미가 불분명한 경우
 
-예: “헬스장 운영시간”, “스터디룸 몇 시까지?”
+────────────────────────
+[slots 규격 — intent별]
 
-RESERVATION_LOOKUP
+A) IOT_CONTROL
+{
+  "device": "LED|AIRCON|HEATER|HUMIDIFIER|FAN|CURTAIN|UNKNOWN",
+  "action": "ON|OFF|TOGGLE|SET|INCREASE|DECREASE|UNKNOWN",
+  "location": "거실|침실|부엌|방1|방2|UNKNOWN",
+  "value": number,
+  "unit": "C|PERCENT|LEVEL|UNKNOWN"
+}
 
-“내 예약/예약 내역/예약 확인” 같이 예약 조회
+B) ENV_STATUS
+{
+  "room": "거실|침실|부엌|화장실|현관|방1|방2|UNKNOWN",
+  "sensor_type": "TEMP|HUMID|PM25|PM10|CO2|GAS|LIGHT|UNKNOWN"
+}
 
-예: “내 예약 내역 보여줘”, “오늘 예약 있어?”
+C) FACILITY_INFO
+{
+  "facility": "헬스장|스터디룸|수영장|경로당|독서실|UNKNOWN",
+  "info_type": "HOURS|AVAILABLE|DESCRIPTION|UNKNOWN"
+}
 
-RAG_POLICY
+※ info_type 규칙
+- 운영시간 질문 → HOURS
+- “예약 가능해?” → AVAILABLE
+- 시설 설명 → DESCRIPTION
 
-관리규약/단지 규정/공지/민원/분리수거/주차 규칙 등 문서 기반 문의
+D) RESERVATION_LOOKUP
+{
+  "scope": "MY|TODAY|UPCOMING|ALL|UNKNOWN",
+  "facility": "헬스장|스터디룸|수영장|UNKNOWN"
+}
 
-예: “분리수거 시간”, “흡연 규정”, “주차 위반 기준”
+E) RAG_POLICY
+{
+  "topic": "주차|분리수거|소음|흡연|반려동물|관리비|엘리베이터|UNKNOWN",
+  "query": "질문 요약 문자열"
+}
 
-SMALL_TALK
+F) SMALL_TALK / UNKNOWN
+{}
+────────────────────────
+[needs_clarification 규칙 — 매우 중요]
 
-인사/잡담/감정 표현(기능 수행과 무관)
+아래 중 하나라도 해당하면 needs_clarification=true:
 
-예: “안녕”, “고마워”, “너 누구야”
+- IOT_CONTROL에서 device/action/location 중 하나라도 UNKNOWN
+- ENV_STATUS에서 room 또는 sensor_type이 UNKNOWN
+- FACILITY_INFO에서 facility가 UNKNOWN
+- RESERVATION_LOOKUP에서 scope가 모호한 경우
+- RAG_POLICY에서 topic이 UNKNOWN
 
-UNKNOWN
+needs_clarification=true 일 때:
+- reply: “확인을 위해 질문할게요.”
+- clarify_question: 선택지를 포함한 질문 1개만 작성
 
-위 어디에도 확실히 속하지 않거나 요청 의미가 불명확
+needs_clarification=false 일 때:
+- clarify_question은 반드시 "" (빈 문자열)
 
-[slots 키 규격 — 절대 변경 금지]
-slots는 intent별로 아래 키만 사용한다. (다른 키 생성 금지)
-
-A) IOT_CONTROL slots
-
-"device": "LED|AIRCON|HEATER|HUMIDIFIER|FAN|CURTAIN|UNKNOWN"
-
-"action": "ON|OFF|TOGGLE|SET|INCREASE|DECREASE|UNKNOWN"
-
-"location": "거실|침실|부엌|방1|방2|UNKNOWN"
-
-"value": number (SET일 때 목표값. 예: 온도 24, 습도 50) / 없으면 생략 가능
-
-"unit": "C|PERCENT|LEVEL|UNKNOWN" (value가 있을 때만. 없으면 생략 가능)
-
-B) ENV_STATUS slots
-
-"room": "거실|침실|부엌|화장실|현관|방1|방2|UNKNOWN"
-
-"sensor_type": "TEMP|HUMID|PM25|PM10|CO2|GAS|LIGHT|UNKNOWN"
-
-C) FACILITY_INFO slots
-
-"facility": "헬스장|스터디룸|수영장|경로당|독서실|UNKNOWN"
-
-"info_type": "HOURS|AVAILABLE|DESCRIPTION|UNKNOWN"
-
-D) RESERVATION_LOOKUP slots
-
-"scope": "MY|TODAY|UPCOMING|ALL|UNKNOWN"
-
-"facility": "헬스장|스터디룸|수영장|UNKNOWN" (사용자가 특정 시설 예약을 언급한 경우만)
-
-E) RAG_POLICY slots
-
-"topic": "주차|분리수거|소음|흡연|반려동물|관리비|엘리베이터|UNKNOWN"
-
-"query": "원문 질문 요약 문자열" (가능하면 1문장으로 짧게)
-
-F) SMALL_TALK slots
-
-비워둔다: {}
-
-G) UNKNOWN slots
-
-비워둔다: {}
-
-[needs_clarification 판단 규칙(매우 중요)]
-다음 중 하나라도 해당하면 needs_clarification=true 로 설정하고, clarify_question에 딱 1개의 질문만 넣어라.
-
-IOT_CONTROL인데 필수 슬롯(device/action/location) 중 하나라도 UNKNOWN 또는 비어 있음
-
-예: “불 꺼줘”(location 없음) → “어느 공간의 불을 끌까요? (거실/침실/부엌…)”
-
-예: “거실 켜줘”(device 없음) → “거실에서 어떤 기기를 켤까요? (LED/에어컨/난방…)”
-
-ENV_STATUS인데 room 또는 sensor_type이 UNKNOWN/비어 있음
-
-예: “온도 알려줘” → “어느 방의 온도를 알려드릴까요? (거실/침실…)”
-
-FACILITY_INFO인데 facility가 UNKNOWN/비어 있음
-
-예: “운영시간 알려줘” → “어느 시설의 운영시간을 알려드릴까요? (헬스장/스터디룸…)”
-
-RESERVATION_LOOKUP인데 scope가 애매하면 scope를 UNKNOWN으로 두고 needs_clarification=true
-
-예: “예약 보여줘” → “어떤 예약을 보여드릴까요? (오늘/다가오는/전체/내 예약)”
-
-RAG_POLICY인데 topic이 UNKNOWN이면 needs_clarification=true
-
-예: “규정 알려줘” → “어떤 규정을 찾을까요? (주차/분리수거/소음/흡연…)”
-
-[clarify_question 규칙]
-
-needs_clarification=true 일 때만 질문을 채운다.
-
-질문은 하나만, 짧고 선택지를 제시한다.
-
-needs_clarification=false 이면 clarify_question은 반드시 ""(빈 문자열)로 둔다.
-
+────────────────────────
 [reply 작성 규칙]
 
-reply는 무조건 짧게 1문장.
-
-DB 조회/실행은 백엔드가 하므로, reply는 “처리 의도/안내” 수준으로만 작성한다.
-
-needs_clarification=true 인 경우 reply는 “확인을 위해 질문할게요.” 같이 매우 짧게.
-
-[최종 출력 예시 — 참고(출력엔 예시 포함 금지)]
-
-“거실 온도 알려줘” → intent=ENV_STATUS, slots={"room":"거실","sensor_type":"TEMP"}, needs_clarification=false
-
-“불 꺼줘” → intent=IOT_CONTROL, slots={"device":"LED","action":"OFF","location":"UNKNOWN"}, needs_clarification=true
+- reply는 반드시 짧은 1문장
+- 실제 DB 조회나 실행은 서버가 처리하므로 결과를 단정하지 않는다
+- 예:
+  - “시설 정보를 확인할게요.”
+  - “예약 상태를 조회할게요.”
+  - “기기를 제어할게요.”


### PR DESCRIPTION
## PR Checklist

PR 전에 다음 요구사항을 충족하고 있는지 확인합시다 :

- [x] 커밋 메시지가 팀 가이드라인을 잘 지키고 있는가?
- [x] 코드의 빌드와 테스트가 정상적으로 통과되었는가?
- [x] MERGE 할 Branch가 맞는지 확인했는가?

## PR Type

현재 PR이 어떤 타입의 PR인지 체크 :

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Fix (Bug Fix)
- [x] Feature (New 기능 개발)
- [ ] Style update (formatting, local variables)
- [ ] Refactoring (functional , API 변경 X)
- [ ] CI/CD 관련 변경
- [ ] Docs (문서 변경)
- [ ] Chore (그 외의 작업) 어떤 작업인지 설명 :

## 연관된 Issue 정보 (#number)
Issue Number: N/A
## 작업한 커밋 내용
*  respon에 label 과 구분해서 label에 하드코딩한 메세지 추천질문으로 뜨게 진행
*  시설에 현재 예약이 가능한지에 대한 대답도 추가 했음 
*  프롬프트 수정 

## Other information



<img width="1409" height="752" alt="image" src="https://github.com/user-attachments/assets/b8d1cf3e-170b-4fde-b9ab-b865c98580d5" />


<img width="1357" height="596" alt="image" src="https://github.com/user-attachments/assets/7715e3f1-4169-401a-a9a6-de851d9fe83e" />


입주민 별 추천 질문의 목록이 나오게 했음 

<img width="359" height="627" alt="image" src="https://github.com/user-attachments/assets/c0c64d00-2bd5-41db-998b-49e719bd84d3" />

프런트에 이런식으로 띄울 예정임 



<img width="1895" height="818" alt="image" src="https://github.com/user-attachments/assets/e50089d9-768a-4db7-a141-75766178d940" />


swagger로 테스트 예약이 가능하고 운영 중이다 라는 확인이 가능하게 추가했음
