### PR TITLE
[FEAT] 공지 board 및 관리자 공지 생성/발송 스코프 구현 (#16)

### DIFF
--- a/src/main/java/com/backend/nova/config/SecurityConfig.java
+++ b/src/main/java/com/backend/nova/config/SecurityConfig.java
@@ -11,6 +11,7 @@ import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.ProviderManager;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -25,6 +26,7 @@ import java.util.List;
 
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity(prePostEnabled = true)
 @RequiredArgsConstructor
 public class SecurityConfig {
 

--- a/src/main/java/com/backend/nova/config/SecurityConfig.java
+++ b/src/main/java/com/backend/nova/config/SecurityConfig.java
@@ -11,7 +11,6 @@ import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.ProviderManager;
-import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -26,7 +25,6 @@ import java.util.List;
 
 @Configuration
 @EnableWebSecurity
-@EnableMethodSecurity(prePostEnabled = true)
 @RequiredArgsConstructor
 public class SecurityConfig {
 

--- a/src/main/java/com/backend/nova/global/exception/ErrorCode.java
+++ b/src/main/java/com/backend/nova/global/exception/ErrorCode.java
@@ -21,6 +21,10 @@ public enum ErrorCode {
     ADMIN_LOCKED(HttpStatus.FORBIDDEN, "계정이 잠금 상태입니다."),
 
 
+    // ================= Notice =================
+    NOTICE_NOT_FOUND(HttpStatus.NOT_FOUND, "공지사항을 찾을 수 없습니다."),
+
+
     // ================= Apartment =================
     APARTMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "아파트를 찾을 수 없습니다."),
 

--- a/src/main/java/com/backend/nova/mqtt/MqttSafetyInboundHandler.java
+++ b/src/main/java/com/backend/nova/mqtt/MqttSafetyInboundHandler.java
@@ -51,7 +51,16 @@ public class MqttSafetyInboundHandler {
     }
 
     private String extractDeviceId(String topic) {
+        if (topic == null || topic.isBlank()) {
+            return null;
+        }
         String[] parts = topic.split("/");
+        if (parts.length != 5) {
+            return null;
+        }
+        if (!"hdc".equals(parts[0]) || !"device".equals(parts[1]) || !"safety".equals(parts[3]) || !"data".equals(parts[4])) {
+            return null;
+        }
         String deviceId = parts[2];
         return deviceId == null || deviceId.isBlank() ? null : deviceId;
     }

--- a/src/main/java/com/backend/nova/notice/controller/AdminNoticeController.java
+++ b/src/main/java/com/backend/nova/notice/controller/AdminNoticeController.java
@@ -1,0 +1,48 @@
+package com.backend.nova.notice.controller;
+
+import com.backend.nova.notice.dto.NoticeCreateRequest;
+import com.backend.nova.notice.dto.NoticeCreateResponse;
+import com.backend.nova.notice.dto.NoticeLogResponse;
+import com.backend.nova.notice.dto.NoticeSendRequest;
+import com.backend.nova.notice.dto.NoticeSendResponse;
+import com.backend.nova.notice.service.NoticeService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/admin/notice")
+@RequiredArgsConstructor
+@PreAuthorize("hasRole('ADMIN')")
+public class AdminNoticeController {
+
+    private final NoticeService noticeService;
+
+    @PostMapping
+    public ResponseEntity<NoticeCreateResponse> createNotice(
+            @RequestBody @Valid NoticeCreateRequest request
+    ) {
+        NoticeCreateResponse response = noticeService.createNotice(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @PostMapping("/{noticeId}/send")
+    public ResponseEntity<NoticeSendResponse> sendNotice(
+            @PathVariable Long noticeId,
+            @RequestBody @Valid NoticeSendRequest request
+    ) {
+        NoticeSendResponse response = noticeService.sendNotice(noticeId, request);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/log")
+    public ResponseEntity<List<NoticeLogResponse>> getLogs() {
+        List<NoticeLogResponse> logs = noticeService.getNoticeLogs();
+        return ResponseEntity.ok(logs);
+    }
+}

--- a/src/main/java/com/backend/nova/notice/controller/AdminNoticeController.java
+++ b/src/main/java/com/backend/nova/notice/controller/AdminNoticeController.java
@@ -31,12 +31,12 @@ public class AdminNoticeController {
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
-    @PostMapping("/{noticeId}/send")
-    public ResponseEntity<NoticeSendResponse> sendNotice(
+    @PostMapping("/{noticeId}/send-alert")
+    public ResponseEntity<NoticeSendResponse> sendNoticeAlert(
             @PathVariable Long noticeId,
             @RequestBody @Valid NoticeSendRequest request
     ) {
-        NoticeSendResponse response = noticeService.sendNotice(noticeId, request);
+        NoticeSendResponse response = noticeService.sendNoticeAlert(noticeId, request);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/backend/nova/notice/controller/NoticeController.java
+++ b/src/main/java/com/backend/nova/notice/controller/NoticeController.java
@@ -1,0 +1,29 @@
+package com.backend.nova.notice.controller;
+
+import com.backend.nova.notice.dto.NoticeBoardResponse;
+import com.backend.nova.notice.service.NoticeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/notice")
+@RequiredArgsConstructor
+public class NoticeController {
+
+    private final NoticeService noticeService;
+
+    @GetMapping
+    public ResponseEntity<List<NoticeBoardResponse>> getMyNotices(
+            @AuthenticationPrincipal User user
+    ) {
+        List<NoticeBoardResponse> notices = noticeService.getNoticesForMember(user.getUsername());
+        return ResponseEntity.ok(notices);
+    }
+}

--- a/src/main/java/com/backend/nova/notice/dto/NoticeBoardResponse.java
+++ b/src/main/java/com/backend/nova/notice/dto/NoticeBoardResponse.java
@@ -1,0 +1,23 @@
+package com.backend.nova.notice.dto;
+
+import com.backend.nova.notice.entity.Notice;
+
+import java.time.LocalDateTime;
+
+public record NoticeBoardResponse(
+        Long noticeId,
+        String title,
+        String content,
+        String authorName,
+        LocalDateTime createdAt
+) {
+    public static NoticeBoardResponse from(Notice notice) {
+        return new NoticeBoardResponse(
+                notice.getId(),
+                notice.getTitle(),
+                notice.getContent(),
+                notice.getAdmin().getName(),
+                notice.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/backend/nova/notice/dto/NoticeCreateRequest.java
+++ b/src/main/java/com/backend/nova/notice/dto/NoticeCreateRequest.java
@@ -1,0 +1,16 @@
+package com.backend.nova.notice.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+import java.util.List;
+
+public record NoticeCreateRequest(
+        @NotBlank(message = "title은 필수입니다.")
+        String title,
+
+        @NotBlank(message = "content는 필수입니다.")
+        String content,
+
+        List<Long> dongIds
+) {
+}

--- a/src/main/java/com/backend/nova/notice/dto/NoticeCreateResponse.java
+++ b/src/main/java/com/backend/nova/notice/dto/NoticeCreateResponse.java
@@ -1,0 +1,7 @@
+package com.backend.nova.notice.dto;
+
+public record NoticeCreateResponse(
+        boolean success,
+        Long noticeId
+) {
+}

--- a/src/main/java/com/backend/nova/notice/dto/NoticeLogResponse.java
+++ b/src/main/java/com/backend/nova/notice/dto/NoticeLogResponse.java
@@ -1,0 +1,27 @@
+package com.backend.nova.notice.dto;
+
+import com.backend.nova.notice.entity.NoticeSendLog;
+
+import java.time.LocalDateTime;
+
+public record NoticeLogResponse(
+        Long id,
+        String type,
+        Long recipientId,
+        String title,
+        String content,
+        LocalDateTime sentAt,
+        boolean read
+) {
+    public static NoticeLogResponse from(NoticeSendLog log) {
+        return new NoticeLogResponse(
+                log.getId(),
+                "notice",
+                log.getRecipientId(),
+                log.getTitle(),
+                log.getContent(),
+                log.getSentAt(),
+                log.isRead()
+        );
+    }
+}

--- a/src/main/java/com/backend/nova/notice/dto/NoticeSendRequest.java
+++ b/src/main/java/com/backend/nova/notice/dto/NoticeSendRequest.java
@@ -1,0 +1,11 @@
+package com.backend.nova.notice.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
+
+public record NoticeSendRequest(
+        List<@NotNull Long> residentIds,
+        List<@NotNull Long> dongIds
+) {
+}

--- a/src/main/java/com/backend/nova/notice/dto/NoticeSendResponse.java
+++ b/src/main/java/com/backend/nova/notice/dto/NoticeSendResponse.java
@@ -1,0 +1,8 @@
+package com.backend.nova.notice.dto;
+
+public record NoticeSendResponse(
+        boolean success,
+        String message,
+        int sentCount
+) {
+}

--- a/src/main/java/com/backend/nova/notice/entity/Notice.java
+++ b/src/main/java/com/backend/nova/notice/entity/Notice.java
@@ -1,0 +1,56 @@
+package com.backend.nova.notice.entity;
+
+import com.backend.nova.admin.entity.Admin;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "notice")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class Notice {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "admin_id", nullable = false)
+    private Admin admin;
+
+    @Column(nullable = false, length = 200)
+    private String title;
+
+    @Lob
+    @Column(nullable = false)
+    private String content;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "target_scope", nullable = false, length = 20)
+    private NoticeTargetScope targetScope;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        LocalDateTime now = LocalDateTime.now();
+        this.createdAt = now;
+        this.updatedAt = now;
+        if (this.targetScope == null) {
+            this.targetScope = NoticeTargetScope.DONG;
+        }
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/backend/nova/notice/entity/NoticeSendLog.java
+++ b/src/main/java/com/backend/nova/notice/entity/NoticeSendLog.java
@@ -1,0 +1,46 @@
+package com.backend.nova.notice.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "notice_send_log")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class NoticeSendLog {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "notice_id", nullable = false)
+    private Notice notice;
+
+    @Column(name = "recipient_id", nullable = false)
+    private Long recipientId;
+
+    @Column(nullable = false, length = 200)
+    private String title;
+
+    @Lob
+    @Column(nullable = false)
+    private String content;
+
+    @Column(name = "sent_at", nullable = false)
+    private LocalDateTime sentAt;
+
+    @Column(name = "is_read", nullable = false)
+    private boolean read;
+
+    @PrePersist
+    protected void onCreate() {
+        if (this.sentAt == null) {
+            this.sentAt = LocalDateTime.now();
+        }
+    }
+}

--- a/src/main/java/com/backend/nova/notice/entity/NoticeTargetDong.java
+++ b/src/main/java/com/backend/nova/notice/entity/NoticeTargetDong.java
@@ -1,0 +1,39 @@
+package com.backend.nova.notice.entity;
+
+import com.backend.nova.apartment.entity.Dong;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+        name = "notice_target_dong",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"notice_id", "dong_id"})
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class NoticeTargetDong {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "notice_id", nullable = false)
+    private Notice notice;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "dong_id", nullable = false)
+    private Dong dong;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/backend/nova/notice/entity/NoticeTargetScope.java
+++ b/src/main/java/com/backend/nova/notice/entity/NoticeTargetScope.java
@@ -1,0 +1,6 @@
+package com.backend.nova.notice.entity;
+
+public enum NoticeTargetScope {
+    ALL,
+    DONG
+}

--- a/src/main/java/com/backend/nova/notice/repository/NoticeRepository.java
+++ b/src/main/java/com/backend/nova/notice/repository/NoticeRepository.java
@@ -1,0 +1,20 @@
+package com.backend.nova.notice.repository;
+
+import com.backend.nova.notice.entity.Notice;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+
+public interface NoticeRepository extends JpaRepository<Notice, Long> {
+
+    @Query("""
+            select distinct n
+            from Notice n
+            left join NoticeTargetDong ntd on ntd.notice = n
+            where n.admin.apartment.id = :apartmentId
+              and (n.targetScope = 'ALL' or ntd.dong.id = :dongId)
+            order by n.createdAt desc
+            """)
+    List<Notice> findBoardNotices(Long apartmentId, Long dongId);
+}

--- a/src/main/java/com/backend/nova/notice/repository/NoticeSendLogRepository.java
+++ b/src/main/java/com/backend/nova/notice/repository/NoticeSendLogRepository.java
@@ -1,0 +1,10 @@
+package com.backend.nova.notice.repository;
+
+import com.backend.nova.notice.entity.NoticeSendLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface NoticeSendLogRepository extends JpaRepository<NoticeSendLog, Long> {
+    List<NoticeSendLog> findAllByOrderBySentAtDesc();
+}

--- a/src/main/java/com/backend/nova/notice/repository/NoticeTargetDongRepository.java
+++ b/src/main/java/com/backend/nova/notice/repository/NoticeTargetDongRepository.java
@@ -1,0 +1,17 @@
+package com.backend.nova.notice.repository;
+
+import com.backend.nova.notice.entity.Notice;
+import com.backend.nova.notice.entity.NoticeTargetDong;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+
+public interface NoticeTargetDongRepository extends JpaRepository<NoticeTargetDong, Long> {
+
+    @Query("select ntd.dong.id from NoticeTargetDong ntd where ntd.notice.id = :noticeId")
+    List<Long> findDongIdsByNoticeId(Long noticeId);
+
+    @Query("select ntd.notice from NoticeTargetDong ntd where ntd.dong.id = :dongId order by ntd.notice.createdAt desc")
+    List<Notice> findNoticesByDongIdOrderByCreatedAtDesc(Long dongId);
+}

--- a/src/main/java/com/backend/nova/notice/service/NoticeService.java
+++ b/src/main/java/com/backend/nova/notice/service/NoticeService.java
@@ -72,7 +72,7 @@ public class NoticeService {
         return new NoticeCreateResponse(true, saved.getId());
     }
 
-    public NoticeSendResponse sendNotice(Long noticeId, NoticeSendRequest request) {
+    public NoticeSendResponse sendNoticeAlert(Long noticeId, NoticeSendRequest request) {
         Notice notice = noticeRepository.findById(noticeId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.NOTICE_NOT_FOUND));
 
@@ -95,7 +95,7 @@ public class NoticeService {
 
         noticeSendLogRepository.saveAll(logs);
 
-        String message = targetResidentIds.size() + "명에게 공지가 전송되었습니다.";
+        String message = targetResidentIds.size() + "명에게 공지 알림이 전송되었습니다.";
         return new NoticeSendResponse(true, message, targetResidentIds.size());
     }
 

--- a/src/main/java/com/backend/nova/notice/service/NoticeService.java
+++ b/src/main/java/com/backend/nova/notice/service/NoticeService.java
@@ -1,0 +1,256 @@
+package com.backend.nova.notice.service;
+
+import com.backend.nova.admin.entity.Admin;
+import com.backend.nova.admin.repository.AdminRepository;
+import com.backend.nova.apartment.entity.Dong;
+import com.backend.nova.apartment.repository.DongRepository;
+import com.backend.nova.global.exception.BusinessException;
+import com.backend.nova.global.exception.ErrorCode;
+import com.backend.nova.member.entity.Member;
+import com.backend.nova.member.repository.MemberRepository;
+import com.backend.nova.notice.dto.NoticeBoardResponse;
+import com.backend.nova.notice.dto.NoticeCreateRequest;
+import com.backend.nova.notice.dto.NoticeCreateResponse;
+import com.backend.nova.notice.dto.NoticeLogResponse;
+import com.backend.nova.notice.dto.NoticeSendRequest;
+import com.backend.nova.notice.dto.NoticeSendResponse;
+import com.backend.nova.notice.entity.Notice;
+import com.backend.nova.notice.entity.NoticeSendLog;
+import com.backend.nova.notice.entity.NoticeTargetDong;
+import com.backend.nova.notice.entity.NoticeTargetScope;
+import com.backend.nova.notice.repository.NoticeRepository;
+import com.backend.nova.notice.repository.NoticeSendLogRepository;
+import com.backend.nova.notice.repository.NoticeTargetDongRepository;
+import com.backend.nova.resident.entity.Resident;
+import com.backend.nova.resident.repository.ResidentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class NoticeService {
+
+    private final NoticeRepository noticeRepository;
+    private final NoticeSendLogRepository noticeSendLogRepository;
+    private final NoticeTargetDongRepository noticeTargetDongRepository;
+    private final AdminRepository adminRepository;
+    private final ResidentRepository residentRepository;
+    private final DongRepository dongRepository;
+    private final MemberRepository memberRepository;
+
+    public NoticeCreateResponse createNotice(NoticeCreateRequest request) {
+        Admin admin = getCurrentAdmin();
+        NoticeTargetScope targetScope = resolveTargetScope(request);
+
+        Notice notice = Notice.builder()
+                .admin(admin)
+                .title(request.title())
+                .content(request.content())
+                .targetScope(targetScope)
+                .build();
+
+        Notice saved = noticeRepository.save(notice);
+        if (targetScope == NoticeTargetScope.DONG) {
+            List<Dong> targets = resolveTargetDongs(request.dongIds(), admin);
+            List<NoticeTargetDong> targetDongs = targets.stream()
+                    .map(dong -> NoticeTargetDong.builder()
+                            .notice(saved)
+                            .dong(dong)
+                            .build())
+                    .toList();
+            noticeTargetDongRepository.saveAll(targetDongs);
+        }
+        return new NoticeCreateResponse(true, saved.getId());
+    }
+
+    public NoticeSendResponse sendNotice(Long noticeId, NoticeSendRequest request) {
+        Notice notice = noticeRepository.findById(noticeId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOTICE_NOT_FOUND));
+
+        Admin admin = getCurrentAdmin();
+        Set<Long> allowedDongIds = resolveAllowedDongIds(notice, admin);
+        if (allowedDongIds.isEmpty()) {
+            throw new BusinessException(ErrorCode.INVALID_REQUEST);
+        }
+        Set<Long> targetResidentIds = resolveTargetResidentIds(request, admin, allowedDongIds);
+
+        List<NoticeSendLog> logs = targetResidentIds.stream()
+                .map(residentId -> NoticeSendLog.builder()
+                        .notice(notice)
+                        .recipientId(residentId)
+                        .title(notice.getTitle())
+                        .content(notice.getContent())
+                        .read(false)
+                        .build())
+                .toList();
+
+        noticeSendLogRepository.saveAll(logs);
+
+        String message = targetResidentIds.size() + "명에게 공지가 전송되었습니다.";
+        return new NoticeSendResponse(true, message, targetResidentIds.size());
+    }
+
+    @Transactional(readOnly = true)
+    public List<NoticeLogResponse> getNoticeLogs() {
+        return noticeSendLogRepository.findAllByOrderBySentAtDesc()
+                .stream()
+                .map(NoticeLogResponse::from)
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public List<NoticeBoardResponse> getNoticesForMember(String loginId) {
+        Member member = memberRepository.findByLoginId(loginId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.UNAUTHORIZED));
+        Long apartmentId = member.getResident().getHo().getDong().getApartment().getId();
+        Long dongId = member.getResident().getHo().getDong().getId();
+        return noticeRepository.findBoardNotices(apartmentId, dongId)
+                .stream()
+                .map(NoticeBoardResponse::from)
+                .toList();
+    }
+
+    private Admin getCurrentAdmin() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || authentication.getName() == null) {
+            throw new BusinessException(ErrorCode.UNAUTHORIZED);
+        }
+        Long adminId;
+        try {
+            adminId = Long.parseLong(authentication.getName());
+        } catch (NumberFormatException e) {
+            throw new BusinessException(ErrorCode.UNAUTHORIZED);
+        }
+        return adminRepository.findById(adminId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ADMIN_NOT_FOUND));
+    }
+
+    private Set<Long> resolveTargetResidentIds(NoticeSendRequest request, Admin admin, Set<Long> allowedDongIds) {
+        if (request == null) {
+            throw new BusinessException(ErrorCode.INVALID_REQUEST);
+        }
+        Set<Long> targetResidentIds = new LinkedHashSet<>();
+
+        List<Long> residentIds = normalizeIds(request.residentIds());
+        if (!residentIds.isEmpty()) {
+            validateResidentIds(residentIds, admin, allowedDongIds);
+            targetResidentIds.addAll(residentIds);
+        }
+
+        List<Long> dongIds = normalizeIds(request.dongIds());
+        if (!dongIds.isEmpty()) {
+            validateDongIds(dongIds, admin, allowedDongIds);
+            List<Resident> residents = residentRepository.findByHo_Dong_IdIn(dongIds);
+            if (residents.isEmpty()) {
+                throw new BusinessException(ErrorCode.INVALID_REQUEST);
+            }
+            residents.stream()
+                    .map(Resident::getId)
+                    .filter(Objects::nonNull)
+                    .forEach(targetResidentIds::add);
+        }
+
+        if (targetResidentIds.isEmpty()) {
+            throw new BusinessException(ErrorCode.INVALID_REQUEST);
+        }
+        return targetResidentIds;
+    }
+
+    private List<Long> normalizeIds(List<Long> ids) {
+        if (ids == null || ids.isEmpty()) {
+            return List.of();
+        }
+        if (ids.stream().anyMatch(Objects::isNull)) {
+            throw new BusinessException(ErrorCode.INVALID_REQUEST);
+        }
+        return ids.stream().distinct().toList();
+    }
+
+    private void validateResidentIds(List<Long> residentIds, Admin admin, Set<Long> allowedDongIds) {
+        List<Resident> residents = residentRepository.findAllById(residentIds);
+        if (residents.size() != residentIds.size()) {
+            throw new BusinessException(ErrorCode.INVALID_REQUEST);
+        }
+        Long apartmentId = admin.getApartment().getId();
+        boolean mismatchApartment = residents.stream()
+                .anyMatch(resident -> !resident.getHo().getDong().getApartment().getId().equals(apartmentId));
+        if (mismatchApartment) {
+            throw new BusinessException(ErrorCode.INVALID_REQUEST);
+        }
+        if (!allowedDongIds.isEmpty()) {
+            boolean notAllowed = residents.stream()
+                    .anyMatch(resident -> !allowedDongIds.contains(resident.getHo().getDong().getId()));
+            if (notAllowed) {
+                throw new BusinessException(ErrorCode.INVALID_REQUEST);
+            }
+        }
+    }
+
+    private void validateDongIds(List<Long> dongIds, Admin admin, Set<Long> allowedDongIds) {
+        List<Dong> dongs = dongRepository.findAllById(dongIds);
+        if (dongs.size() != dongIds.size()) {
+            throw new BusinessException(ErrorCode.INVALID_REQUEST);
+        }
+        Long apartmentId = admin.getApartment().getId();
+        boolean mismatchApartment = dongs.stream()
+                .anyMatch(dong -> !dong.getApartment().getId().equals(apartmentId));
+        if (mismatchApartment) {
+            throw new BusinessException(ErrorCode.INVALID_REQUEST);
+        }
+        if (!allowedDongIds.isEmpty() && !allowedDongIds.containsAll(dongIds)) {
+            throw new BusinessException(ErrorCode.INVALID_REQUEST);
+        }
+    }
+
+    private List<Dong> resolveTargetDongs(List<Long> dongIds, Admin admin) {
+        List<Long> normalized = normalizeIds(dongIds);
+        List<Dong> dongs = normalized.isEmpty()
+                ? dongRepository.findAllByApartmentId(admin.getApartment().getId())
+                : dongRepository.findAllById(normalized);
+
+        if (dongs.isEmpty()) {
+            throw new BusinessException(ErrorCode.INVALID_REQUEST);
+        }
+
+        if (!normalized.isEmpty() && dongs.size() != normalized.size()) {
+            throw new BusinessException(ErrorCode.INVALID_REQUEST);
+        }
+
+        Long apartmentId = admin.getApartment().getId();
+        boolean mismatchApartment = dongs.stream()
+                .anyMatch(dong -> !dong.getApartment().getId().equals(apartmentId));
+        if (mismatchApartment) {
+            throw new BusinessException(ErrorCode.INVALID_REQUEST);
+        }
+
+        return dongs;
+    }
+
+    private NoticeTargetScope resolveTargetScope(NoticeCreateRequest request) {
+        if (request == null) {
+            throw new BusinessException(ErrorCode.INVALID_REQUEST);
+        }
+        List<Long> dongIds = normalizeIds(request.dongIds());
+        return dongIds.isEmpty() ? NoticeTargetScope.ALL : NoticeTargetScope.DONG;
+    }
+
+    private Set<Long> resolveAllowedDongIds(Notice notice, Admin admin) {
+        if (notice.getTargetScope() == NoticeTargetScope.ALL) {
+            List<Dong> dongs = dongRepository.findAllByApartmentId(admin.getApartment().getId());
+            return dongs.stream()
+                    .map(Dong::getId)
+                    .filter(Objects::nonNull)
+                    .collect(java.util.stream.Collectors.toCollection(LinkedHashSet::new));
+        }
+        return new LinkedHashSet<>(noticeTargetDongRepository.findDongIdsByNoticeId(notice.getId()));
+    }
+}

--- a/src/main/java/com/backend/nova/resident/repository/ResidentRepository.java
+++ b/src/main/java/com/backend/nova/resident/repository/ResidentRepository.java
@@ -23,4 +23,6 @@ public interface ResidentRepository extends JpaRepository<Resident, Long> {
     @EntityGraph(attributePaths = {"ho"})
     Optional<Resident> findWithHoById(Long id);
 
+    List<Resident> findByHo_Dong_IdIn(List<Long> dongIds);
+
 }

--- a/src/test/java/com/backend/nova/mqtt/MqttInboundHandlerTest.java
+++ b/src/test/java/com/backend/nova/mqtt/MqttInboundHandlerTest.java
@@ -1,0 +1,102 @@
+package com.backend.nova.mqtt;
+
+import com.backend.nova.safety.dto.SafetySensorInboundPayload;
+import com.backend.nova.safety.service.SafetyService;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.integration.mqtt.support.MqttHeaders;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.MessageBuilder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class MqttInboundHandlerTest {
+
+    @Mock
+    private ObjectMapper objectMapper;
+
+    @Mock
+    private SafetyService safetyService;
+
+    @InjectMocks
+    private MqttSafetyInboundHandler mqttInboundHandler;
+
+    @Test
+    void ignoresInvalidTopic() {
+        // topic 패턴 불일치면 무시
+        Message<String> message = message("hdc/device/s1/safety", "{\"deviceId\":\"s1\"}");
+        mqttInboundHandler.handleSafetyMessage(message);
+        verifyNoInteractions(objectMapper, safetyService);
+    }
+
+    @Test
+    void ignoresInvalidPayload() throws Exception {
+        // 필수 필드 누락이면 서비스 호출하지 않음
+        Message<String> message = message("hdc/device/s1/safety/data", "{\"deviceId\":\"s1\"}");
+        when(objectMapper.readValue(eq(message.getPayload()), eq(SafetySensorInboundPayload.class)))
+                .thenReturn(new SafetySensorInboundPayload(null, 1.0, "ppm", "2024-01-01T00:00:00Z"));
+
+        mqttInboundHandler.handleSafetyMessage(message);
+
+        verify(safetyService, never()).handleSafetySensor(anyString(), any());
+    }
+
+    @Test
+    void ignoresPayloadWhenMissingUnit() throws Exception {
+        // 필수 필드 누락이면 서비스 호출하지 않음
+        Message<String> message = message("hdc/device/s1/safety/data", "{\"deviceId\":\"s1\"}");
+        when(objectMapper.readValue(eq(message.getPayload()), eq(SafetySensorInboundPayload.class)))
+                .thenReturn(new SafetySensorInboundPayload("SMOKE", 1.0, null, "2024-01-01T00:00:00Z"));
+
+        mqttInboundHandler.handleSafetyMessage(message);
+
+        verify(safetyService, never()).handleSafetySensor(anyString(), any());
+    }
+
+    @Test
+    void routesValidMessageToService() throws Exception {
+        // 정상 메시지는 서비스로 전달
+        Message<String> message = message("hdc/device/s1/safety/data", "{\"deviceId\":\"s1\"}");
+        SafetySensorInboundPayload payload = new SafetySensorInboundPayload(
+                "SMOKE",
+                10.0,
+                "ppm",
+                "2024-01-01T00:00:00Z"
+        );
+        when(objectMapper.readValue(eq(message.getPayload()), eq(SafetySensorInboundPayload.class)))
+                .thenReturn(payload);
+
+        mqttInboundHandler.handleSafetyMessage(message);
+
+        ArgumentCaptor<SafetySensorInboundPayload> captor = ArgumentCaptor.forClass(SafetySensorInboundPayload.class);
+        verify(safetyService).handleSafetySensor(eq("s1"), captor.capture());
+        assertThat(captor.getValue()).isEqualTo(payload);
+    }
+
+    @Test
+    void ignoresWhenPayloadParseFails() throws Exception {
+        // JSON 파싱 실패 시 무시
+        Message<String> message = message("hdc/device/s1/safety/data", "{\"deviceId\":\"s1\"}");
+        when(objectMapper.readValue(eq(message.getPayload()), eq(SafetySensorInboundPayload.class)))
+                .thenThrow(new JsonProcessingException("boom") {});
+
+        mqttInboundHandler.handleSafetyMessage(message);
+
+        verify(safetyService, never()).handleSafetySensor(anyString(), any());
+    }
+
+    private Message<String> message(String topic, String payload) {
+        return MessageBuilder.withPayload(payload)
+                .setHeader(MqttHeaders.RECEIVED_TOPIC, topic)
+                .build();
+    }
+}

--- a/src/test/java/com/backend/nova/notice/controller/AdminNoticeControllerIntegrationTest.java
+++ b/src/test/java/com/backend/nova/notice/controller/AdminNoticeControllerIntegrationTest.java
@@ -1,0 +1,241 @@
+package com.backend.nova.notice.controller;
+
+import com.backend.nova.admin.entity.Admin;
+import com.backend.nova.admin.entity.AdminRole;
+import com.backend.nova.admin.entity.AdminStatus;
+import com.backend.nova.admin.repository.AdminRepository;
+import com.backend.nova.apartment.entity.Apartment;
+import com.backend.nova.apartment.entity.Dong;
+import com.backend.nova.apartment.entity.Ho;
+import com.backend.nova.apartment.repository.ApartmentRepository;
+import com.backend.nova.apartment.repository.DongRepository;
+import com.backend.nova.apartment.repository.HoRepository;
+import com.backend.nova.notice.dto.NoticeCreateRequest;
+import com.backend.nova.notice.dto.NoticeCreateResponse;
+import com.backend.nova.notice.dto.NoticeSendRequest;
+import com.backend.nova.notice.repository.NoticeRepository;
+import com.backend.nova.notice.repository.NoticeSendLogRepository;
+import com.backend.nova.notice.repository.NoticeTargetDongRepository;
+import com.backend.nova.resident.entity.Resident;
+import com.backend.nova.resident.repository.ResidentRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestPropertySource(properties = {
+        "spring.datasource.url=jdbc:h2:mem:testdb;MODE=MySQL;DB_CLOSE_DELAY=-1",
+        "spring.datasource.driver-class-name=org.h2.Driver",
+        "spring.datasource.username=sa",
+        "spring.datasource.password=",
+        "spring.jpa.hibernate.ddl-auto=create-drop",
+        "spring.jpa.show-sql=false",
+        "jwt.secret=MzJieXRlLXNlY3JldC1rZXktZm9yLWp3dC10ZXN0LSEhISE=",
+        "jwt.access-token-expire-time=3600000",
+        "jwt.refresh-token-expire-time=604800000"
+})
+class AdminNoticeControllerIntegrationTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @Autowired
+    AdminRepository adminRepository;
+
+    @Autowired
+    ApartmentRepository apartmentRepository;
+
+    @Autowired
+    DongRepository dongRepository;
+
+    @Autowired
+    HoRepository hoRepository;
+
+    @Autowired
+    ResidentRepository residentRepository;
+
+    @Autowired
+    NoticeRepository noticeRepository;
+
+    @Autowired
+    NoticeSendLogRepository noticeSendLogRepository;
+
+    @Autowired
+    NoticeTargetDongRepository noticeTargetDongRepository;
+
+    @BeforeEach
+    void cleanDb() {
+        noticeSendLogRepository.deleteAllInBatch();
+        noticeTargetDongRepository.deleteAllInBatch();
+        noticeRepository.deleteAllInBatch();
+        residentRepository.deleteAllInBatch();
+        hoRepository.deleteAllInBatch();
+        dongRepository.deleteAllInBatch();
+        adminRepository.deleteAllInBatch();
+        apartmentRepository.deleteAllInBatch();
+    }
+
+    @Test
+    @DisplayName("관리자 공지 등록/발송/로그 조회 통합 테스트")
+    void noticeFlow_success() throws Exception {
+        Apartment apartment = createApartment();
+        Admin admin = createAdmin(apartment);
+        Ho ho = createHo(createDong(apartment));
+        Resident resident1 = createResident(ho, "김영희", "010-0000-0001");
+        Resident resident2 = createResident(ho, "이영희", "010-0000-0002");
+
+        NoticeCreateRequest createRequest = new NoticeCreateRequest("정기 소독 안내", "다음주 화요일 소독 예정", null);
+
+        String createResponseJson = mockMvc.perform(post("/api/admin/notice")
+                        .with(user(admin.getId().toString()).roles("ADMIN"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(createRequest)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.noticeId").isNumber())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        NoticeCreateResponse createResponse = objectMapper.readValue(createResponseJson, NoticeCreateResponse.class);
+
+        NoticeSendRequest sendRequest = new NoticeSendRequest(
+                List.of(resident1.getId(), resident2.getId()),
+                null
+        );
+
+        mockMvc.perform(post("/api/admin/notice/{noticeId}/send", createResponse.noticeId())
+                        .with(user(admin.getId().toString()).roles("ADMIN"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(sendRequest)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.sentCount").value(2));
+
+        mockMvc.perform(get("/api/admin/notice/log")
+                        .with(user(admin.getId().toString()).roles("ADMIN")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(2)))
+                .andExpect(jsonPath("$[0].type").value("notice"));
+    }
+
+    @Test
+    @DisplayName("공지 전송 - 공지 없음")
+    void sendNotice_notFound() throws Exception {
+        Apartment apartment = createApartment();
+        Admin admin = createAdmin(apartment);
+
+        NoticeSendRequest sendRequest = new NoticeSendRequest(List.of(1L), null);
+
+        mockMvc.perform(post("/api/admin/notice/{noticeId}/send", 999L)
+                        .with(user(admin.getId().toString()).roles("ADMIN"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(sendRequest)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("NOTICE_NOT_FOUND"));
+    }
+
+    private Apartment createApartment() {
+        Apartment apartment = Apartment.builder()
+                .name("테스트 아파트-" + UUID.randomUUID())
+                .address("서울시 테스트구 테스트동")
+                .latitude(37.5665)
+                .longitude(126.9780)
+                .build();
+        return apartmentRepository.saveAndFlush(apartment);
+    }
+
+    private Dong createDong(Apartment apartment) {
+        Dong dong = Dong.builder()
+                .apartment(apartment)
+                .dongNo("101")
+                .build();
+        return dongRepository.saveAndFlush(dong);
+    }
+
+    private Ho createHo(Dong dong) {
+        Ho ho = Ho.builder()
+                .dong(dong)
+                .hoNo("1001")
+                .floor(10)
+                .build();
+        return hoRepository.saveAndFlush(ho);
+    }
+
+    private Resident createResident(Ho ho, String name, String phone) {
+        Resident resident = Resident.builder()
+                .ho(ho)
+                .name(name)
+                .phone(phone)
+                .build();
+        return residentRepository.saveAndFlush(resident);
+    }
+
+    private Admin createAdmin(Apartment apartment) {
+        String uuid = UUID.randomUUID().toString();
+        Admin admin = Admin.builder()
+                .loginId("admin-" + uuid)
+                .email("admin-" + uuid + "@test.com")
+                .passwordHash("pw")
+                .name("테스트 관리자")
+                .role(AdminRole.ADMIN)
+                .status(AdminStatus.ACTIVE)
+                .failedLoginCount(0)
+                .apartment(apartment)
+                .build();
+        return adminRepository.saveAndFlush(admin);
+    }
+
+    @Test
+    @DisplayName("공지 전송 - 동 단위 전송")
+    void sendNotice_byDong() throws Exception {
+        Apartment apartment = createApartment();
+        Admin admin = createAdmin(apartment);
+        Dong dong = createDong(apartment);
+        Ho ho = createHo(dong);
+        createResident(ho, "김영희", "010-0000-0001");
+        createResident(ho, "이영희", "010-0000-0002");
+
+        NoticeCreateRequest createRequest = new NoticeCreateRequest("공지", "동 공지", List.of(dong.getId()));
+        String createResponseJson = mockMvc.perform(post("/api/admin/notice")
+                        .with(user(admin.getId().toString()).roles("ADMIN"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(createRequest)))
+                .andExpect(status().isCreated())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+        NoticeCreateResponse createResponse = objectMapper.readValue(createResponseJson, NoticeCreateResponse.class);
+
+        NoticeSendRequest sendRequest = new NoticeSendRequest(null, List.of(dong.getId()));
+
+        mockMvc.perform(post("/api/admin/notice/{noticeId}/send", createResponse.noticeId())
+                        .with(user(admin.getId().toString()).roles("ADMIN"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(sendRequest)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.sentCount").value(2));
+    }
+}

--- a/src/test/java/com/backend/nova/notice/controller/AdminNoticeControllerIntegrationTest.java
+++ b/src/test/java/com/backend/nova/notice/controller/AdminNoticeControllerIntegrationTest.java
@@ -125,7 +125,7 @@ class AdminNoticeControllerIntegrationTest {
                 null
         );
 
-        mockMvc.perform(post("/api/admin/notice/{noticeId}/send", createResponse.noticeId())
+        mockMvc.perform(post("/api/admin/notice/{noticeId}/send-alert", createResponse.noticeId())
                         .with(user(admin.getId().toString()).roles("ADMIN"))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(sendRequest)))
@@ -148,7 +148,7 @@ class AdminNoticeControllerIntegrationTest {
 
         NoticeSendRequest sendRequest = new NoticeSendRequest(List.of(1L), null);
 
-        mockMvc.perform(post("/api/admin/notice/{noticeId}/send", 999L)
+        mockMvc.perform(post("/api/admin/notice/{noticeId}/send-alert", 999L)
                         .with(user(admin.getId().toString()).roles("ADMIN"))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(sendRequest)))
@@ -230,7 +230,7 @@ class AdminNoticeControllerIntegrationTest {
 
         NoticeSendRequest sendRequest = new NoticeSendRequest(null, List.of(dong.getId()));
 
-        mockMvc.perform(post("/api/admin/notice/{noticeId}/send", createResponse.noticeId())
+        mockMvc.perform(post("/api/admin/notice/{noticeId}/send-alert", createResponse.noticeId())
                         .with(user(admin.getId().toString()).roles("ADMIN"))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(sendRequest)))

--- a/src/test/java/com/backend/nova/notice/service/NoticeServiceTest.java
+++ b/src/test/java/com/backend/nova/notice/service/NoticeServiceTest.java
@@ -1,0 +1,286 @@
+package com.backend.nova.notice.service;
+
+import com.backend.nova.admin.entity.Admin;
+import com.backend.nova.admin.entity.AdminRole;
+import com.backend.nova.admin.entity.AdminStatus;
+import com.backend.nova.admin.repository.AdminRepository;
+import com.backend.nova.apartment.entity.Apartment;
+import com.backend.nova.global.exception.BusinessException;
+import com.backend.nova.global.exception.ErrorCode;
+import com.backend.nova.notice.dto.NoticeCreateRequest;
+import com.backend.nova.notice.dto.NoticeCreateResponse;
+import com.backend.nova.notice.dto.NoticeSendRequest;
+import com.backend.nova.notice.dto.NoticeSendResponse;
+import com.backend.nova.notice.dto.NoticeBoardResponse;
+import com.backend.nova.notice.entity.Notice;
+import com.backend.nova.notice.entity.NoticeSendLog;
+import com.backend.nova.notice.repository.NoticeRepository;
+import com.backend.nova.notice.repository.NoticeSendLogRepository;
+import com.backend.nova.notice.repository.NoticeTargetDongRepository;
+import com.backend.nova.apartment.repository.DongRepository;
+import com.backend.nova.member.entity.LoginType;
+import com.backend.nova.member.entity.Member;
+import com.backend.nova.member.repository.MemberRepository;
+import com.backend.nova.resident.entity.Resident;
+import com.backend.nova.resident.repository.ResidentRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class NoticeServiceTest {
+
+    @Mock
+    NoticeRepository noticeRepository;
+
+    @Mock
+    NoticeSendLogRepository noticeSendLogRepository;
+
+    @Mock
+    NoticeTargetDongRepository noticeTargetDongRepository;
+
+    @Mock
+    AdminRepository adminRepository;
+
+    @Mock
+    ResidentRepository residentRepository;
+
+    @Mock
+    DongRepository dongRepository;
+
+    @Mock
+    MemberRepository memberRepository;
+
+    @InjectMocks
+    NoticeService noticeService;
+
+    @AfterEach
+    void clearSecurityContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    @DisplayName("공지 생성 - 성공")
+    void createNotice_success() {
+        setAdminAuthentication(1L);
+        Apartment apartment = Apartment.builder()
+                .id(1L)
+                .name("Test Apt")
+                .address("Address")
+                .latitude(0.0)
+                .longitude(0.0)
+                .build();
+        Admin admin = Admin.builder()
+                .id(1L)
+                .loginId("admin1")
+                .passwordHash("pw")
+                .name("Admin")
+                .email("admin@test.com")
+                .role(AdminRole.ADMIN)
+                .status(AdminStatus.ACTIVE)
+                .apartment(apartment)
+                .build();
+        when(adminRepository.findById(1L)).thenReturn(Optional.of(admin));
+        com.backend.nova.apartment.entity.Dong dong = com.backend.nova.apartment.entity.Dong.builder()
+                .id(10L)
+                .apartment(apartment)
+                .dongNo("101")
+                .build();
+        when(dongRepository.findAllById(List.of(10L))).thenReturn(List.of(dong));
+
+        Notice saved = Notice.builder()
+                .id(10L)
+                .admin(admin)
+                .title("Title")
+                .content("Content")
+                .targetScope(com.backend.nova.notice.entity.NoticeTargetScope.ALL)
+                .build();
+        when(noticeRepository.save(any(Notice.class))).thenReturn(saved);
+        when(noticeTargetDongRepository.saveAll(any()))
+                .thenReturn(List.of(mock(com.backend.nova.notice.entity.NoticeTargetDong.class)));
+
+        NoticeCreateResponse response = noticeService.createNotice(new NoticeCreateRequest("Title", "Content", List.of(10L)));
+
+        assertThat(response.success()).isTrue();
+        assertThat(response.noticeId()).isEqualTo(10L);
+        verify(noticeRepository).save(any(Notice.class));
+    }
+
+    @Test
+    @DisplayName("공지 전송 - 입주민 ID 검증 실패")
+    void sendNotice_invalidResidents() {
+        setAdminAuthentication(1L);
+        Admin admin = buildAdmin(1L);
+        when(adminRepository.findById(1L)).thenReturn(Optional.of(admin));
+
+        Notice notice = Notice.builder()
+                .id(1L)
+                .title("Title")
+                .content("Content")
+                .targetScope(com.backend.nova.notice.entity.NoticeTargetScope.DONG)
+                .build();
+        when(noticeRepository.findById(1L)).thenReturn(Optional.of(notice));
+        when(noticeTargetDongRepository.findDongIdsByNoticeId(1L)).thenReturn(List.of(200L));
+        when(residentRepository.findAllById(List.of(1L, 2L)))
+                .thenReturn(List.of(mock(Resident.class)));
+
+        NoticeSendRequest request = new NoticeSendRequest(List.of(1L, 2L), null);
+
+        assertThatThrownBy(() -> noticeService.sendNotice(1L, request))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> {
+                    BusinessException be = (BusinessException) ex;
+                    assertThat(be.getErrorCode()).isEqualTo(ErrorCode.INVALID_REQUEST);
+                });
+
+        verify(noticeSendLogRepository, never()).saveAll(any());
+    }
+
+    @Test
+    @DisplayName("공지 전송 - 성공")
+    void sendNotice_success() {
+        setAdminAuthentication(1L);
+        Admin admin = buildAdmin(1L);
+        when(adminRepository.findById(1L)).thenReturn(Optional.of(admin));
+
+        Notice notice = Notice.builder()
+                .id(1L)
+                .title("Title")
+                .content("Content")
+                .targetScope(com.backend.nova.notice.entity.NoticeTargetScope.DONG)
+                .build();
+        when(noticeRepository.findById(1L)).thenReturn(Optional.of(notice));
+        when(noticeTargetDongRepository.findDongIdsByNoticeId(1L)).thenReturn(List.of(200L));
+        Apartment apartment = admin.getApartment();
+        com.backend.nova.apartment.entity.Dong dong = com.backend.nova.apartment.entity.Dong.builder()
+                .id(200L)
+                .apartment(apartment)
+                .dongNo("101")
+                .build();
+        com.backend.nova.apartment.entity.Ho ho = com.backend.nova.apartment.entity.Ho.builder()
+                .id(300L)
+                .dong(dong)
+                .hoNo("1001")
+                .floor(10)
+                .build();
+        Resident resident1 = Resident.builder()
+                .id(1L)
+                .ho(ho)
+                .name("김영희")
+                .phone("010-0000-0001")
+                .build();
+        Resident resident2 = Resident.builder()
+                .id(2L)
+                .ho(ho)
+                .name("이영희")
+                .phone("010-0000-0002")
+                .build();
+        when(residentRepository.findAllById(List.of(1L, 2L)))
+                .thenReturn(List.of(resident1, resident2));
+        when(noticeSendLogRepository.saveAll(any()))
+                .thenReturn(List.of(mock(NoticeSendLog.class), mock(NoticeSendLog.class)));
+
+        NoticeSendResponse response = noticeService.sendNotice(1L, new NoticeSendRequest(List.of(1L, 2L), null));
+
+        assertThat(response.success()).isTrue();
+        assertThat(response.sentCount()).isEqualTo(2);
+        verify(noticeSendLogRepository).saveAll(any());
+    }
+
+    @Test
+    @DisplayName("멤버 공지 조회 - 동 기준")
+    void getNoticesForMember_success() {
+        com.backend.nova.apartment.entity.Apartment apartment = Apartment.builder()
+                .id(1L)
+                .name("Test Apt")
+                .address("Address")
+                .latitude(0.0)
+                .longitude(0.0)
+                .build();
+        com.backend.nova.apartment.entity.Dong dong = com.backend.nova.apartment.entity.Dong.builder()
+                .id(200L)
+                .apartment(apartment)
+                .dongNo("101")
+                .build();
+        com.backend.nova.apartment.entity.Ho ho = com.backend.nova.apartment.entity.Ho.builder()
+                .id(300L)
+                .dong(dong)
+                .hoNo("1001")
+                .floor(10)
+                .build();
+        Resident resident = Resident.builder()
+                .id(1L)
+                .ho(ho)
+                .name("김영희")
+                .phone("010-0000-0001")
+                .build();
+        Member member = Member.builder()
+                .id(5L)
+                .resident(resident)
+                .loginId("user1")
+                .password("pw")
+                .name("김영희")
+                .loginType(LoginType.NORMAL)
+                .build();
+        when(memberRepository.findByLoginId("user1")).thenReturn(Optional.of(member));
+
+        Notice notice = Notice.builder()
+                .id(1L)
+                .admin(buildAdmin(1L))
+                .title("공지 제목")
+                .content("공지 내용")
+                .targetScope(com.backend.nova.notice.entity.NoticeTargetScope.ALL)
+                .build();
+        when(noticeRepository.findBoardNotices(1L, 200L))
+                .thenReturn(List.of(notice));
+
+        List<NoticeBoardResponse> responses = noticeService.getNoticesForMember("user1");
+
+        assertThat(responses).hasSize(1);
+        assertThat(responses.get(0).title()).isEqualTo("공지 제목");
+    }
+
+    private void setAdminAuthentication(Long adminId) {
+        UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+                adminId.toString(),
+                null,
+                List.of(new SimpleGrantedAuthority("ROLE_ADMIN"))
+        );
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+
+    private Admin buildAdmin(Long adminId) {
+        Apartment apartment = Apartment.builder()
+                .id(1L)
+                .name("Test Apt")
+                .address("Address")
+                .latitude(0.0)
+                .longitude(0.0)
+                .build();
+        return Admin.builder()
+                .id(adminId)
+                .loginId("admin1")
+                .passwordHash("pw")
+                .name("Admin")
+                .email("admin@test.com")
+                .role(AdminRole.ADMIN)
+                .status(AdminStatus.ACTIVE)
+                .apartment(apartment)
+                .build();
+    }
+}

--- a/src/test/java/com/backend/nova/notice/service/NoticeServiceTest.java
+++ b/src/test/java/com/backend/nova/notice/service/NoticeServiceTest.java
@@ -141,7 +141,7 @@ class NoticeServiceTest {
 
         NoticeSendRequest request = new NoticeSendRequest(List.of(1L, 2L), null);
 
-        assertThatThrownBy(() -> noticeService.sendNotice(1L, request))
+        assertThatThrownBy(() -> noticeService.sendNoticeAlert(1L, request))
                 .isInstanceOf(BusinessException.class)
                 .satisfies(ex -> {
                     BusinessException be = (BusinessException) ex;
@@ -195,7 +195,7 @@ class NoticeServiceTest {
         when(noticeSendLogRepository.saveAll(any()))
                 .thenReturn(List.of(mock(NoticeSendLog.class), mock(NoticeSendLog.class)));
 
-        NoticeSendResponse response = noticeService.sendNotice(1L, new NoticeSendRequest(List.of(1L, 2L), null));
+        NoticeSendResponse response = noticeService.sendNoticeAlert(1L, new NoticeSendRequest(List.of(1L, 2L), null));
 
         assertThat(response.success()).isTrue();
         assertThat(response.sentCount()).isEqualTo(2);


### PR DESCRIPTION
## 개요
Notice 도메인을 신규 추가하고, 관리자 공지 생성/발송/로그 조회 및 입주민 공지 조회 API를 구현했습니다.

## 주요 변경 사항

### 1) Notice 도메인 신규 구현
- Entity
  - `Notice`
  - `NoticeSendLog`
  - `NoticeTargetDong`
  - `NoticeTargetScope`
- Repository
  - `NoticeRepository`
  - `NoticeSendLogRepository`
  - `NoticeTargetDongRepository`
- Service
  - `NoticeService`

### 2) 관리자 공지 API 추가
- `POST /api/admin/notice` : 공지 생성
- `POST /api/admin/notice/{noticeId}/send` : 공지 발송 (입주민/동 범위 지정)
- `GET /api/admin/notice/log` : 공지 발송 로그 조회

### 3) 입주민 공지 조회 API 추가
- `GET /api/notice` : 로그인 입주민 기준 공지 게시판 조회

### 4) 공통/보조 변경
- `ErrorCode`에 `NOTICE_NOT_FOUND` 추가
- `SecurityConfig`에 `@EnableMethodSecurity(prePostEnabled = true)` 적용
- `ResidentRepository.findByHo_Dong_IdIn(...)` 추가
- `MqttSafetyInboundHandler.extractDeviceId` 토픽 형식 검증 강화 (null/blank/형식 체크)

결과:
- `AdminNoticeControllerIntegrationTest`: 3 passed
- `NoticeServiceTest`: 4 passed
- `MqttInboundHandlerTest`: 5 passed

